### PR TITLE
ftag: fix broken test

### DIFF
--- a/ftag/ftag_test.go
+++ b/ftag/ftag_test.go
@@ -27,8 +27,7 @@ func TestWrapWithKindChanging(t *testing.T) {
 }
 
 func TestWrapNil(t *testing.T) {
-	err := Wrap(nil, NotFound)
-	out := Get(err)
-
-	assert.Equal(t, None, out)
+	assert.Panics(t, func() {
+		Wrap(nil, NotFound)
+	})
 }


### PR DESCRIPTION
Calling `ftag.Wrap(nil, ...)` will panic and the test is not asserting it.