### PR TITLE
fmsg: only append non-empty external messages

### DIFF
--- a/fmsg/fmsg.go
+++ b/fmsg/fmsg.go
@@ -66,7 +66,9 @@ func GetIssues(err error) []Issue {
 
 	for err != nil {
 		if wm, ok := err.(*withMessage); ok {
-			p = append(p, wm.external)
+			if wm.external != "" {
+				p = append(p, wm.external)
+			}
 		}
 
 		err = errors.Unwrap(err)


### PR DESCRIPTION
Minor adjustment that gets rid of useless empty Issues.