### PR TITLE
Fix-missing-root-error-messages

### DIFF
--- a/fault.go
+++ b/fault.go
@@ -30,17 +30,12 @@ func Wrap(err error, w ...Wrapper) error {
 		location: getLocation(),
 	}
 
-	if _, ok := err.(*container); !ok {
-		c.end = true
-	}
-
 	return c
 }
 
 type container struct {
 	cause    error
 	location string
-	end      bool // is this the last one in the chain before an external error?
 }
 
 // Error behaves like most error wrapping libraries, it gives you all the error

--- a/tests/flatten_test.go
+++ b/tests/flatten_test.go
@@ -157,3 +157,28 @@ func TestFlattenStdlibErrorfWrappedExternalError(t *testing.T) {
 	a.Equal("", e2.Message)
 	a.Contains(e2.Location, "test_callers.go:11")
 }
+
+func TestFlattenStdlibErrorfWrappedExternallyWrappedError(t *testing.T) {
+	a := assert.New(t)
+
+	err := rootCause(8)
+	chain := fault.Flatten(err)
+	full := err.Error()
+	root := chain.Root.Error()
+
+	a.Equal("failed to call function: external error wrapped with pkg/errors: github.com/pkg/errors external error", full)
+	a.Equal("github.com/pkg/errors external error", root)
+	a.Len(chain.Errors, 3)
+
+	e0 := chain.Errors[0]
+	a.Equal("external error wrapped with pkg/errors: github.com/pkg/errors external error", e0.Message)
+	a.Contains(e0.Location, "test_callers.go:29")
+
+	e1 := chain.Errors[1]
+	a.Equal("failed to call function", e1.Message)
+	a.Contains(e1.Location, "test_callers.go:20")
+
+	e2 := chain.Errors[2]
+	a.Equal("", e2.Message)
+	a.Contains(e2.Location, "test_callers.go:11")
+}


### PR DESCRIPTION
Problem being solved in this PR:

this error tree actually omits the underlying error when formatting. This is due to the error type not giving a useful propagation of error messages and the top-most Fault wrap doesn't capture this.

What needs to happen is if the current AND next error are not wrappers, a new error must be appended to the list.

```
error(*github.com/Southclaws/fault.container) *{
    cause: error(*github.com/Southclaws/fault/fmsg.withMessage) *{
        underlying: error(*fmt.wrapError) *{
            msg: "sql/schema: modify \"group_members\" table: ERROR: column \"group_id\" of relation \"group_members\" contains null values (SQLSTATE 23502)",
            err: error(*fmt.wrapError) *{
                msg: "modify \"group_members\" table: ERROR: column \"group_id\" of relation \"group_members\" contains null values (SQLSTATE 23502)",
                err: error(*github.com/jackc/pgconn.PgError) *{
                    Severity: "ERROR",
                    Code: "23502",
                    Message: "column \"group_id\" of relation \"group_members\" contains null values",
                    Detail: "",
                    Hint: "",
                    Position: 0,
                    InternalPosition: 0,
                    InternalQuery: "",
                    Where: "",
                    SchemaName: "public",
                    TableName: "group_members",
                    ColumnName: "group_id",
                    DataTypeName: "",
                    ConstraintName: "",
                    File: "tablecmds.c",
                    Line: 5515,
                    Routine: "ATRewriteTable",
                }
            }
        },
        internal: "failed to migrate schema", 
        external: ""
    }, 
    location: "app/db/db.go:83", 
    end: true
}
```