### PR TITLE
fctx: allow to pass 'kv strings' to fctx.With

### DIFF
--- a/fctx/fctx.go
+++ b/fctx/fctx.go
@@ -60,7 +60,7 @@ func WithMeta(ctx context.Context, kv ...string) context.Context {
 //
 //	user, err := database.GetUser(ctx, userID)
 //	if err != nil {
-//		return nil, fctx.Wrap(ctx, err, "role", "admin")
+//		return nil, fctx.Wrap(err, ctx, "role", "admin")
 //	}
 //
 // This library aims to be simple so there is no stack trace collection or
@@ -68,8 +68,8 @@ func WithMeta(ctx context.Context, kv ...string) context.Context {
 //
 //	user, err := database.GetUser(ctx, userID)
 //	if err != nil {
-//		return nil, fctx.Wrap(ctx,
-//			errors.Wrap(err, "failed to get user data"),
+//		return nil, fctx.Wrap(errors.Wrap(err, "failed to get user data"),
+//			ctx,
 //			"role", "admin")
 //	}
 func Wrap(err error, ctx context.Context, kv ...string) error {


### PR DESCRIPTION

When calling fctx.Wrap with context which doesn't have contextKey{} (not made with fctx.WithMeta, like context.Background()), don't prematurely return. This allows to use context.Background() when you need to return an error with additional data, and you don't have a passed context or that context is passed, but is not “special” (not enhanced with fctx.WithMeta). So if you pass this empty context, and finally return using wrap with additional arguments, those arguments will dissapear:
```go
return fctx.Wrap(err, ctx, // empty context without contextKey{}
	"data_from", dateFrom.Format(time.DateOnly),
	"data_to", dateTo.Format(time.DateOnly),
)
```

Also this change allows this pattern:
```go
return fault.Wrap(err,
	fmsg.With("Service: ..."),
	fctx.With(context.Background(),
		"data_from", dateFrom.Format(time.DateOnly),
		"data_to", dateTo.Format(time.DateOnly),
	),
)
```
Instead of a previous more verbose:
```go
return fault.Wrap(err,
	fmsg.With("Service: ..."),
	fctx.With(
		fctx.WithMeta(context.Background(),
			"data_from", dateFrom.Format(time.DateOnly),
			"data_to", dateTo.Format(time.DateOnly),
		),
	),
)
```


